### PR TITLE
ENH: added docstring scoping for void triple quoted strings

### DIFF
--- a/grammars/julia.cson
+++ b/grammars/julia.cson
@@ -268,6 +268,32 @@ repository:
   string:
     patterns: [
       {
+        begin: '^\\s?(\\w+)?(""")\\s?$'
+        beginCaptures:
+          '1':
+            'name': 'support.function.macro.julia'
+          '2':
+            'name': 'punctuation.definition.string.begin.julia'
+        end: '\\s?^(""")\\s?$'
+        endCaptures:
+          '1':
+            'name': 'punctuation.definition.string.end.julia'
+        name: 'string.docstring.julia'
+        contentName : 'source.gfm'
+        comment: """
+        This only matches docstrings that start and end with triple quotes on
+        their own line in the void
+        """
+        patterns: [
+          {
+            include: 'source.gfm'
+          }
+          {
+            include: '#string_escaped_char'
+          }
+        ]
+      }
+      {
         begin: "'"
         beginCaptures:
           "0":
@@ -368,8 +394,10 @@ repository:
         contentName : 'source.gfm'
         patterns: [
           {
-            include: '#string_escaped_char'
             include: 'source.gfm'
+          }
+          {
+            include: '#string_escaped_char'
           }
         ]
       }

--- a/spec/julia-spec.coffee
+++ b/spec/julia-spec.coffee
@@ -43,6 +43,17 @@ describe "Julia grammar", ->
     expect(tokens[0]).toEqual value: "@doc", scopes: ["source.julia", "string.docstring.julia", "support.function.macro.julia"]
     expect(tokens[2]).toEqual value: "doc\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.begin.julia"]
 
+  it "tokenizes void docstrings", ->
+    {tokens} = grammar.tokenizeLine("""\"\"\"
+    docstring
+
+    foo bar
+    \"\"\"
+    """)
+    expect(tokens[0]).toEqual value: '"""', scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.begin.julia"]
+    expect(tokens[1]).toEqual value: "\ndocstring\n\nfoo bar", scopes: ["source.julia", "string.docstring.julia", "source.gfm"]
+    expect(tokens[3]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.end.julia"]
+
   # code is a line from Gadfly.jl
   it "tokenizes function calls starting with double quotes", ->
     {tokens} = grammar.tokenizeLine("warn(\"$(string(key)) is not a recognized aesthetic. Ignoring.\")")


### PR DESCRIPTION
Only works for docstrings that start and end with triple quotes on
their own line in the void