### PR TITLE
add note about different plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Atom package for the Julia language. Originally based off of [JuliaLang/julia.tm
 
 Installation happens normally either through `apm install language-julia` or through the install section of the settings tab within Atom.
 
-Note: if you already have a different version of language-julia plugin installed (e.g. [this one](https://github.com/tpoisot/language-julia)), you would need to remove it first using `apm install language-julia`
+Note: if you already have a different version of language-julia plugin installed (e.g. [this one](https://github.com/tpoisot/language-julia)), you would need to remove it first using `apm uninstall language-julia`
 
 ## Contributors:
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Atom package for the Julia language. Originally based off of [JuliaLang/julia.tm
 
 Installation happens normally either through `apm install language-julia` or through the install section of the settings tab within Atom.
 
+Note: if you already have a different version of language-julia plugin installed (e.g. [this one](https://github.com/tpoisot/language-julia)), you would need to remove it first using `apm install language-julia`
+
 ## Contributors:
 
 - Everyone who has helped with the [tmBundle](https://github.com/JuliaLang/Julia.tmbundle)


### PR DESCRIPTION
Add a note about previous plugin removal as discussed in Issue #11.

Another note: what will happen if we will bump up the version of this plugin beyond the version of the previous one? https://github.com/tpoisot/language-julia is on version 0.9.0 now, if this one will get bumped to 0.10 it might trigger Atom to update (as they share names). I'm not sure how to test it though.