### PR TITLE
Don't override global whitespace setting

### DIFF
--- a/settings/language-julia.cson
+++ b/settings/language-julia.cson
@@ -5,8 +5,6 @@
   editor:
     increaseIndentPattern: "^(\\s*|.*=\\s*|.*@\\w*\\s*)(if|while|for|function|stagedfunction|macro|immutable|type|let|quote|try|begin|.*\\)\\s*do|else|elseif|catch|finally)\\b(?!.*\\bend\\b[^\\]]*$).*$"
     decreaseIndentPattern: "^\\s*(end|else|elseif|catch|finally)\\b.*$"
-    softTabs: true
-    tabLength: 4
     foldingStartMarker: "^\\s*(?:if|while|for|begin|function|macro|module|baremodule|type|immutable|try|let)\\b(?!.*\\bend\\b).*$"
     foldingStopMarker: "^\\s*(?:end)\\b.*$"
 


### PR DESCRIPTION
These whitespace settings override the global ones, which is confusing if you they aren't the settings you want when working on Julia (and you're expecting your usual ones to apply).

Atom's tab settings are very easy to change by hand, so I think it's be best to let users decide what they want (and let them use their global setting if desired) rather than surprising them.