### PR TITLE
Refactor keyword.operator scopes to maximise ligature coverage

### DIFF
--- a/grammars/julia.cson
+++ b/grammars/julia.cson
@@ -212,7 +212,11 @@ repository:
   operator:
     patterns: [
       {
-        match: "(?:=|:=|\\+=|-=|\\*=|/=|//=|\\.//=|\\.\\*=|\\\\=|\\.\\\\=|^=|\\.^=|%=|\\|=|&=|\\$=|<<=|>>=)"
+        match: "(?:\\.==|!=|\\.>=|\\.>=|\\.>|\\.<|==|\\.!=|\\.=|\\.!|<:|:>|>=|<=|>|<)"
+        name: "keyword.operator.relation.julia"
+      }
+      {
+        match: "(?::=|\\+=|-=|\\*=|//=|/=|\\.//=|\\.\\*=|\\\\=|\\.\\\\=|^=|\\.^=|%=|\\|=|&=|\\$=|<<=|>>=|=)"
         name: "keyword.operator.update.julia"
       }
       {
@@ -228,24 +232,20 @@ repository:
         name: "keyword.operator.ternary.julia"
       }
       {
-        match: "(?:\\|\\||&&|(?<![[:word:]])!)"
-        name: "keyword.operator.boolean.julia"
-      }
-      {
         match: "(?:->|<-|-->)"
         name: "keyword.operator.arrow.julia"
       }
       {
-        match: "(?:>|<|>=|<=|==|!=|\\.>|\\.<|\\.>=|\\.>=|\\.==|\\.!=|\\.=|\\.!|<:|:>)"
-        name: "keyword.operator.relation.julia"
+        match: "(?:<<|>>)"
+        name: "keyword.operator.shift.julia"
+      }
+      {
+        match: "(?:\\|\\||&&|(?<![[:word:]])!)"
+        name: "keyword.operator.boolean.julia"
       }
       {
         match: "(?::)"
         name: "keyword.operator.range.julia"
-      }
-      {
-        match: "(?:<<|>>)"
-        name: "keyword.operator.shift.julia"
       }
       {
         match: "(?:\\||\\&|~)"


### PR DESCRIPTION
Fixes #49.

Based on the bug discussion, it is apparent that the operator scoping is separating ligatures. I've reordered either the regex order, pattern match order (ie which pattern is matched first in the file) or both. Attempting to minimise changes though.

Rule of thumb for future additions: put the most complicated matches first, simple matches like `=` should go last in the regex. 

I'm pretty sure I've caught all Julia-legal ligatures here, and no behavioural change in any syntax highlighting should occur.