### PR TITLE
Fix syntax colouring bug with docstrings

### DIFF
--- a/grammars/julia.cson
+++ b/grammars/julia.cson
@@ -343,7 +343,7 @@ repository:
             'name': 'support.function.macro.julia'
           '2':
             'name': 'punctuation.definition.string.begin.julia'
-        end: '\\s?^(""")\\s?'
+        end: '\\s?^\\s*(""")\\s?'
         endCaptures:
           '1':
             'name': 'punctuation.definition.string.end.julia'

--- a/spec/julia-spec.coffee
+++ b/spec/julia-spec.coffee
@@ -139,11 +139,12 @@ describe "Julia grammar", ->
   
   it "tokenizes void docstrings with whitespace after the final newline, but before the close-quote", ->
     {tokens} = grammar.tokenizeLine("""\"\"\"
-    This is a simple test
+    docstring
+
+    foo bar
         \"\"\"""")
     expect(tokens[0]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.begin.julia"]
-    expect(tokens[1]).toEqual value: "\nThis is a simple test", scopes: ["source.julia", "string.docstring.julia", "source.gfm"]
-    expect(tokens[2]).toEqual value: "\n", scopes: ["source.julia", "string.docstring.julia"]
+    expect(tokens[1]).toEqual value: "\ndocstring\n\nfoo bar", scopes: ["source.julia", "string.docstring.julia", "source.gfm"]
     expect(tokens[3]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.end.julia"]
 
   it "tokenizes void docstrings that have extra content after ending tripe quote", ->

--- a/spec/julia-spec.coffee
+++ b/spec/julia-spec.coffee
@@ -139,8 +139,7 @@ describe "Julia grammar", ->
     expect(tokens[3]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.end.julia"]
   
   it "tokenizes void docstrings with whitespace after the final newline, but before the close-quote", ->
-    {tokens} = grammar.tokenizeLine(
-    """\"\"\"
+    {tokens} = grammar.tokenizeLine("""\"\"\"
         This is a simple test
         \"\"\"""")
     expect(tokens[0]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.end.julia", "punctuation.definition.string.begin.julia"]

--- a/spec/julia-spec.coffee
+++ b/spec/julia-spec.coffee
@@ -132,16 +132,15 @@ describe "Julia grammar", ->
     docstring
 
     foo bar
-    \"\"\"
-    """)
+    \"\"\"""")
     expect(tokens[0]).toEqual value: '"""', scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.begin.julia"]
     expect(tokens[1]).toEqual value: "\ndocstring\n\nfoo bar", scopes: ["source.julia", "string.docstring.julia", "source.gfm"]
     expect(tokens[3]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.end.julia"]
   
   it "tokenizes void docstrings with whitespace after the final newline, but before the close-quote", ->
     {tokens} = grammar.tokenizeLine("""\"\"\"
-    \s\s\s\sThis is a simple test
-    \s\s\s\s\"\"\"""")
+    This is a simple test
+        \"\"\"""")
     expect(tokens[0]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.begin.julia"]
     expect(tokens[1]).toEqual value: "\nThis is a simple test", scopes: ["source.julia", "string.docstring.julia", "source.gfm"]
     expect(tokens[2]).toEqual value: "\n", scopes: ["source.julia", "string.docstring.julia"]

--- a/spec/julia-spec.coffee
+++ b/spec/julia-spec.coffee
@@ -142,10 +142,10 @@ describe "Julia grammar", ->
     {tokens} = grammar.tokenizeLine("""\"\"\"
         This is a simple test
         \"\"\"""")
-    expect(tokens[0]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.end.julia", "punctuation.definition.string.begin.julia"]
-    expect(tokens[1]).toEqual value: "\nThis is a simple test", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.end.julia", "punctuation.definition.string.begin.julia"]
-    expect(tokens[2]).toEqual value: "\n", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.end.julia", "punctuation.definition.string.begin.julia"]
-    expect(tokens[3]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.end.julia", "punctuation.definition.string.begin.julia"]
+    expect(tokens[0]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.begin.julia"]
+    expect(tokens[1]).toEqual value: "\nThis is a simple test", scopes: ["source.julia", "string.docstring.julia", "source.gfm"]
+    expect(tokens[2]).toEqual value: "\n", scopes: ["source.julia", "string.docstring.julia"]
+    expect(tokens[3]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.end.julia"]
 
   it "tokenizes void docstrings that have extra content after ending tripe quote", ->
     {tokens} = grammar.tokenizeLine("""\"\"\"

--- a/spec/julia-spec.coffee
+++ b/spec/julia-spec.coffee
@@ -137,6 +137,15 @@ describe "Julia grammar", ->
     expect(tokens[0]).toEqual value: '"""', scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.begin.julia"]
     expect(tokens[1]).toEqual value: "\ndocstring\n\nfoo bar", scopes: ["source.julia", "string.docstring.julia", "source.gfm"]
     expect(tokens[3]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.end.julia"]
+  
+  it "tokenizes void docstrings with whitespace after the final newline, but before the close-quote", ->
+    {tokens} = grammar.tokenizeLine(
+    """\"\"\"
+        This is a simple test
+        \"\"\"""")
+    expect(tokens[0]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.end.julia", "punctuation.definition.string.begin.julia"]
+    expect(tokens[1]).toEqual value: "This is a simple test", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.end.julia", "punctuation.definition.string.begin.julia"]
+    expect(tokens[2]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.end.julia", "punctuation.definition.string.begin.julia"]
 
   it "tokenizes void docstrings that have extra content after ending tripe quote", ->
     {tokens} = grammar.tokenizeLine("""\"\"\"

--- a/spec/julia-spec.coffee
+++ b/spec/julia-spec.coffee
@@ -140,8 +140,8 @@ describe "Julia grammar", ->
   
   it "tokenizes void docstrings with whitespace after the final newline, but before the close-quote", ->
     {tokens} = grammar.tokenizeLine("""\"\"\"
-        This is a simple test
-        \"\"\"""")
+    \s\s\s\sThis is a simple test
+    \s\s\s\s\"\"\"""")
     expect(tokens[0]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.begin.julia"]
     expect(tokens[1]).toEqual value: "\nThis is a simple test", scopes: ["source.julia", "string.docstring.julia", "source.gfm"]
     expect(tokens[2]).toEqual value: "\n", scopes: ["source.julia", "string.docstring.julia"]

--- a/spec/julia-spec.coffee
+++ b/spec/julia-spec.coffee
@@ -143,8 +143,9 @@ describe "Julia grammar", ->
         This is a simple test
         \"\"\"""")
     expect(tokens[0]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.end.julia", "punctuation.definition.string.begin.julia"]
-    expect(tokens[1]).toEqual value: "This is a simple test", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.end.julia", "punctuation.definition.string.begin.julia"]
-    expect(tokens[2]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.end.julia", "punctuation.definition.string.begin.julia"]
+    expect(tokens[1]).toEqual value: "\nThis is a simple test", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.end.julia", "punctuation.definition.string.begin.julia"]
+    expect(tokens[2]).toEqual value: "\n", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.end.julia", "punctuation.definition.string.begin.julia"]
+    expect(tokens[3]).toEqual value: "\"\"\"", scopes: ["source.julia", "string.docstring.julia", "punctuation.definition.string.end.julia", "punctuation.definition.string.begin.julia"]
 
   it "tokenizes void docstrings that have extra content after ending tripe quote", ->
     {tokens} = grammar.tokenizeLine("""\"\"\"


### PR DESCRIPTION
Triple-quoted docstrings break syntax colouring due to leading whitespace immediately before the closing quotes. Julia required a trailing indent in the string to parse the Markdown properly.
While this is presumably a bug in Julia, I figure this is something that should be permitted anyway.