### PR TITLE
autoindent fix

### DIFF
--- a/settings/language-julia.cson
+++ b/settings/language-julia.cson
@@ -3,7 +3,7 @@
     commentStart: "# "
 ".source.julia:not(.string)":
   editor:
-    increaseIndentPattern: "^(\\s*|.*=\\s*|.*@\\w*\\s*)(if|while|for|function|stagedfunction|macro|immutable|type|let|quote|try|begin|.*\\)\\s*do|else|elseif|catch|finally)\\b(?!.*\\bend\\b[^\\]]*$).*$"
+    increaseIndentPattern: "(if|while|for|function|stagedfunction|macro|immutable|type|let|quote|try|begin|.*\\)\\s*do|else|elseif|catch|finally)\\b(?!.*\\bend\\b[^\\]]*$).*$"
     decreaseIndentPattern: "^\\s*(end|else|elseif|catch|finally)\\b.*$"
     foldingStartMarker: "^\\s*(?:if|while|for|begin|function|macro|module|baremodule|type|immutable|try|let)\\b(?!.*\\bend\\b).*$"
     foldingStopMarker: "^\\s*(?:end)\\b.*$"


### PR DESCRIPTION
Not sure how correct this is, but I think there's no need to match *everything* since the start of the line.

Fixes #37. And hopefully doesn't break anything else... :)