### PR TITLE
Don't treat throw specially

### DIFF
--- a/grammars/julia.cson
+++ b/grammars/julia.cson
@@ -162,7 +162,7 @@ repository:
         name: "keyword.other.julia"
       }
       {
-        match: "\\b(?<![:_])(?:if|else|elseif|while|for|in|begin|let|do|try|catch|finally|return|break|throw|continue)\\b"
+        match: "\\b(?<![:_])(?:if|else|elseif|while|for|in|begin|let|do|try|catch|finally|return|break|continue)\\b"
         name: "keyword.control.julia"
       }
       {


### PR DESCRIPTION
`throw` seems to be the only function that is highlighted differently, as if it were syntax. While it's true that `throw` is special, since of course it isn't a generic function, it's still a function just like `is`, `isa`, and `typeof`, which aren't highlighted differently.

Even worse, moreover, the highlighting doesn't even work properly, because (at least on my installation) the function call highlighting syntax seems to take precedence. This happens even for `if` and `while`, which makes highlighting for the non-idiomatic style `if(x)` weird (but that's a separate bug entirely). But while it's not normal for `if` to be followed by parentheses, `throw` is almost always followed by parentheses.

So the only time currently that `throw` is highlighted like syntax is in a construct like `map(throw, x)`, where I don't think the highlighting is even desirable.

Hence, I think it's a good idea simply to remove it from the keywords list.